### PR TITLE
remove: github-actionsの設定を削除

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,13 +20,6 @@
   ],
   "rebaseWhen": "conflicted",
   "labels": ["dependencies"],
-  "github-actions": {
-    "fileMatch": [
-      "^(workflow-templates|\\.(?:github|gitea|forgejo)/workflows)/[^/]+\\.ya?ml$",
-      "(^|/)action\\.ya?ml$",
-      "\\.github/actions/.+\\.ya?ml$"
-    ]
-  },
   "packageRules": [
     {
       "description": "Automerge patch and minor updates for node-version",


### PR DESCRIPTION
## 概要

`default.json` から `github-actions` の `fileMatch` 設定を丸ごと削除。