### PR TITLE
pnpmのminor/patchバージョンをautomergeする設定を追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,6 +54,12 @@
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Automerge patch and minor updates for pnpm",
+      "matchPackageNames": ["pnpm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## 概要

- pnpmのminor/patchバージョンアップデートを自動マージする設定を`packageRules`に追加

## 変更内容

- `default.json`にpnpm用のautomergeルールを追加
  - `matchPackageNames`: `pnpm`
  - `matchUpdateTypes`: `minor`, `patch`
  - `automerge`: `true`

## テストプラン

- [ ] Renovateが正しくpnpmのminor/patchアップデートを自動マージすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)